### PR TITLE
如果字段类型可以为null 则添加 Nullable,否则同步mysql回报nil异常

### DIFF
--- a/pkg/mysqlx/clickhouse.go
+++ b/pkg/mysqlx/clickhouse.go
@@ -29,6 +29,10 @@ func ToClickhouseTable(dsn, db, table, indexes string, withTime bool) ([]string,
 		}
 		// type converter
 		columns[i].Type = toClickhouseType(c.Type)
+		// 如果字段类型可以为null 则添加 Nullable,否则同步mysql回报nil异常
+		if c.Null == "YES" {
+			columns[i].Type = "Nullable(" + columns[i].Type + ")"
+		}
 		newColumns = append(newColumns, table2.Column{
 			Name:    columns[i].Field,
 			Type:    columns[i].Type,


### PR DESCRIPTION
在同步mysql数据时候，发现当字段可以为Null，并且数据是Null的时候，dm 数据同步报nil异常的异常

> {"@timestamp":"2021-01-04T17:03:44.268+08","level":"error","content":"mysqltypeconv.go:59 sql: Scan error on column index 4, name \"Default\":
>  converting NULL to string is unsupported"}

通过如下代码可以解决